### PR TITLE
feat: Enable Global Function Snippets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Run syntax tests in Sublime Text 3 via **Tools > Build** with the test file open
 ## Active Technologies
 - JSON (TextMate grammar, VS Code snippets, language config); Node.js for tooling/testing + VS Code Extension API (declarative — no runtime code needed); `vscode-tmgrammar-test` (dev dependency for grammar testing) (002-vscode-extension-migration)
 - JSON (declarative extension manifest); Node.js >=20.x (tooling only) + `@vscode/vsce` (packaging CLI) (004-vscode-extension-compose)
+- XML (Sublime snippets), JSON (VS Code snippets) — declarative, no runtime code + None — pure editor configuration files (005-global-function-snippets)
 
 ## Recent Changes
 - 004-vscode-extension-compose: Added `@vscode/vsce` for extension packaging; Marketplace metadata, README, CHANGELOG, LICENSE, icon

--- a/specs/005-global-function-snippets/checklists/requirements.md
+++ b/specs/005-global-function-snippets/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Global Function Snippets
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- FR-004/FR-005 reference snippet placeholder syntax (`${1:a}`) which is a format convention, not an implementation detail — this is acceptable as it defines the expected user-facing behavior.
+- FR-006 mentions "Sublime Text" and "VS Code" as target platforms — this is scope definition, not implementation detail.
+- All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/005-global-function-snippets/plan.md
+++ b/specs/005-global-function-snippets/plan.md
@@ -1,0 +1,130 @@
+# Implementation Plan: Global Function Snippets
+
+**Branch**: `005-global-function-snippets` | **Date**: 2026-02-15 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/005-global-function-snippets/spec.md`
+
+## Summary
+
+Add snippet definitions for the 5 AviUtl global functions (`OR`, `AND`, `XOR`, `SHIFT`, `debug_print`) that are already recognized by the syntax grammar but lack corresponding snippets. Snippets are added in both Sublime Text `.sublime-snippet` format and VS Code `.code-snippets` JSON format, following the exact patterns established by the existing `obj.*` method snippets.
+
+## Technical Context
+
+**Language/Version**: XML (Sublime snippets), JSON (VS Code snippets) — declarative, no runtime code
+**Primary Dependencies**: None — pure editor configuration files
+**Storage**: N/A
+**Testing**: Manual snippet trigger verification in both editors; `vscode-tmgrammar-test` for grammar (no changes to grammar, but confirms no regressions)
+**Target Platform**: Sublime Text 3, VS Code 1.80+
+**Project Type**: Editor extension package (declarative)
+**Performance Goals**: N/A — snippets are statically loaded by the editor
+**Constraints**: None — additive change only
+**Scale/Scope**: 5 new Sublime snippet files + 5 new entries in VS Code snippet JSON
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+| --------- | ------ | ----- |
+| I. Simplicity (YAGNI) | PASS | Each snippet file solves a concrete, current need (missing autocompletion for known functions). No abstractions introduced. |
+| II. Test-First (TDD) | PASS | TDD applies to behavioral changes. Snippets are declarative data — they will be verified by manual trigger tests and by ensuring the VS Code grammar tests still pass. |
+| III. Syntax Fidelity | N/A | No grammar/scope changes. Snippets use existing scope `source.lua.aviutl-script`. |
+| IV. Backward Compatibility | PASS | Additive only — 5 new files in Sublime `snippet/function/`, 5 new entries in VS Code JSON. No existing files modified except appending to the VS Code snippets JSON. |
+| V. Single Source of Truth | PASS | Function names and signatures are sourced from the AviUtl scripting reference. Snippet content matches grammar patterns already defined in both `AviUtl.sublime-syntax` and `aviutl-script.tmLanguage.json`. |
+| Keyword Accuracy | PASS | All 5 functions (`OR`, `AND`, `XOR`, `SHIFT`, `debug_print`) already exist in the grammar files, verified against the AviUtl reference. |
+
+No violations. No complexity tracking needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/005-global-function-snippets/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+sublime-aviutl-script/
+└── snippet/
+    └── function/
+        ├── OR.sublime-snippet          # NEW
+        ├── AND.sublime-snippet         # NEW
+        ├── XOR.sublime-snippet         # NEW
+        ├── SHIFT.sublime-snippet       # NEW
+        └── debug_print.sublime-snippet # NEW
+
+vscode-aviutl-script/
+└── snippets/
+    └── aviutl-script.code-snippets     # MODIFIED (5 entries appended)
+```
+
+**Structure Decision**: Follows existing convention — each Sublime snippet is a separate `.sublime-snippet` file in `snippet/function/`, while VS Code snippets are all in the single `aviutl-script.code-snippets` JSON file. Global functions (not prefixed with `obj.`) get their own snippet files named after the function.
+
+## Snippet Definitions
+
+### Sublime Text Snippets
+
+Each `.sublime-snippet` file follows this template:
+
+```xml
+<snippet>
+	<scope>source.lua.aviutl-script</scope>
+	<description>{Japanese description}</description>
+	<content><![CDATA[
+{expansion}
+]]></content>
+	<tabTrigger>{trigger}</tabTrigger>
+</snippet>
+```
+
+| File | Trigger | Expansion | Description |
+| ---- | ------- | --------- | ----------- |
+| `OR.sublime-snippet` | `OR` | `OR(${1:a},${2:b})$0` | OR,AND,XORのビット演算をします。 |
+| `AND.sublime-snippet` | `AND` | `AND(${1:a},${2:b})$0` | OR,AND,XORのビット演算をします。 |
+| `XOR.sublime-snippet` | `XOR` | `XOR(${1:a},${2:b})$0` | OR,AND,XORのビット演算をします。 |
+| `SHIFT.sublime-snippet` | `SHIFT` | `SHIFT(${1:a},${2:b})$0` | 算術シフトをします。 |
+| `debug_print.sublime-snippet` | `debug_print` | `debug_print(${1:str})$0` | デバック用の表示に使用します。 |
+
+### VS Code Snippet Entries
+
+Appended to `aviutl-script.code-snippets`:
+
+```json
+"OR": {
+  "prefix": "OR",
+  "body": "OR(${1:a},${2:b})$0",
+  "description": "OR,AND,XORのビット演算をします。"
+},
+"AND": {
+  "prefix": "AND",
+  "body": "AND(${1:a},${2:b})$0",
+  "description": "OR,AND,XORのビット演算をします。"
+},
+"XOR": {
+  "prefix": "XOR",
+  "body": "XOR(${1:a},${2:b})$0",
+  "description": "OR,AND,XORのビット演算をします。"
+},
+"SHIFT": {
+  "prefix": "SHIFT",
+  "body": "SHIFT(${1:a},${2:b})$0",
+  "description": "算術シフトをします。"
+},
+"debug_print": {
+  "prefix": "debug_print",
+  "body": "debug_print(${1:str})$0",
+  "description": "デバック用の表示に使用します。"
+}
+```
+
+## Implementation Sequence
+
+1. Create 5 Sublime `.sublime-snippet` files in `sublime-aviutl-script/snippet/function/`
+2. Append 5 entries to `vscode-aviutl-script/snippets/aviutl-script.code-snippets`
+3. Run `vscode-tmgrammar-test` to confirm no regressions
+4. Manual verification of snippet triggers in both editors

--- a/specs/005-global-function-snippets/quickstart.md
+++ b/specs/005-global-function-snippets/quickstart.md
@@ -1,0 +1,27 @@
+# Quickstart: Global Function Snippets
+
+## What's Being Added
+
+5 snippet definitions for AviUtl global functions: `OR`, `AND`, `XOR`, `SHIFT`, `debug_print`.
+
+## Files to Create
+
+### Sublime Text (5 new files)
+
+Create each file in `sublime-aviutl-script/snippet/function/`:
+
+- `OR.sublime-snippet` — trigger: `OR`, expands to `OR(a,b)`
+- `AND.sublime-snippet` — trigger: `AND`, expands to `AND(a,b)`
+- `XOR.sublime-snippet` — trigger: `XOR`, expands to `XOR(a,b)`
+- `SHIFT.sublime-snippet` — trigger: `SHIFT`, expands to `SHIFT(a,b)`
+- `debug_print.sublime-snippet` — trigger: `debug_print`, expands to `debug_print(str)`
+
+### VS Code (1 modified file)
+
+Append 5 entries to `vscode-aviutl-script/snippets/aviutl-script.code-snippets` (before the closing `}`).
+
+## Verification
+
+1. Run existing grammar tests: `cd vscode-aviutl-script && npm test`
+2. In Sublime Text 3: open a `.obj` file, type `OR` + Tab → should expand
+3. In VS Code: open a `.obj` file, type `OR` → autocomplete should offer the snippet

--- a/specs/005-global-function-snippets/research.md
+++ b/specs/005-global-function-snippets/research.md
@@ -1,0 +1,39 @@
+# Research: Global Function Snippets
+
+## Decision: Function Signatures
+
+**Decision**: Use the signatures documented in the AviUtl scripting reference.
+**Rationale**: These functions are already defined in the syntax grammar (`AviUtl.sublime-syntax` line 28, `aviutl-script.tmLanguage.json` line 22). Their signatures are well-established.
+**Alternatives considered**: None — the AviUtl reference is the single authoritative source.
+
+| Function | Signature | Arguments |
+| -------- | --------- | --------- |
+| `OR` | `OR(a, b)` | Two numeric operands |
+| `AND` | `AND(a, b)` | Two numeric operands |
+| `XOR` | `XOR(a, b)` | Two numeric operands |
+| `SHIFT` | `SHIFT(a, b)` | Value and shift amount |
+| `debug_print` | `debug_print(str)` | String to display |
+
+## Decision: Snippet File Organization
+
+**Decision**: Place global function snippets in `sublime-aviutl-script/snippet/function/` alongside existing `obj.*` method snippets. Name each file after the function (e.g., `OR.sublime-snippet`).
+**Rationale**: The existing `snippet/function/` directory contains all callable function snippets. Global functions are conceptually similar to `obj.*` methods — they are callable functions the user invokes. Keeping them in the same directory maintains discoverability and follows the established convention.
+**Alternatives considered**: Creating a separate `snippet/function/global/` subdirectory — rejected as unnecessary complexity for 5 files (violates Principle I: Simplicity).
+
+## Decision: Japanese Descriptions
+
+**Decision**: Use descriptions as provided in the user's feature request, which match the AviUtl scripting reference.
+**Rationale**: Consistency with existing snippets that all use Japanese descriptions from the same reference.
+
+| Function | Description |
+| -------- | ----------- |
+| `OR` | OR,AND,XORのビット演算をします。 |
+| `AND` | OR,AND,XORのビット演算をします。 |
+| `XOR` | OR,AND,XORのビット演算をします。 |
+| `SHIFT` | 算術シフトをします。 |
+| `debug_print` | デバック用の表示に使用します。 |
+
+## Decision: No Grammar Changes Needed
+
+**Decision**: No changes to `AviUtl.sublime-syntax` or `aviutl-script.tmLanguage.json`.
+**Rationale**: All 5 functions are already matched by the existing grammar pattern `\b(OR|AND|XOR|RGB|HSV|SHIFT|debug_print)\b` and scoped as `support.function.library.aviutl-script`. Only snippets (autocompletion templates) are missing.

--- a/specs/005-global-function-snippets/spec.md
+++ b/specs/005-global-function-snippets/spec.md
@@ -1,0 +1,84 @@
+# Feature Specification: Global Function Snippets
+
+**Feature Branch**: `005-global-function-snippets`
+**Created**: 2026-02-15
+**Status**: Draft
+**Input**: User description: "Add snippets for several functions: OR, AND, XOR (ビット演算), SHIFT (算術シフト), debug_print (デバック用の表示)"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Bitwise Operation Snippet Insertion (Priority: P1)
+
+An AviUtl script author needs to perform bitwise operations (OR, AND, XOR) on values. They type the function name as a trigger word and use tab-completion to insert the snippet with placeholders for both arguments.
+
+**Why this priority**: Bitwise operations (OR, AND, XOR) share the same two-argument signature `(a, b)` and are the most commonly used global functions among the requested set. Delivering all three together provides immediate value.
+
+**Independent Test**: Can be fully tested by typing `OR`, `AND`, or `XOR` in an AviUtl script file and triggering autocomplete. Each snippet expands to the function call with tab-stop placeholders for arguments.
+
+**Acceptance Scenarios**:
+
+1. **Given** an AviUtl script file is open in the editor, **When** the user types `OR` and triggers snippet expansion, **Then** the editor inserts `OR(a, b)` with `a` and `b` as tab-stop placeholders.
+2. **Given** an AviUtl script file is open in the editor, **When** the user types `AND` and triggers snippet expansion, **Then** the editor inserts `AND(a, b)` with `a` and `b` as tab-stop placeholders.
+3. **Given** an AviUtl script file is open in the editor, **When** the user types `XOR` and triggers snippet expansion, **Then** the editor inserts `XOR(a, b)` with `a` and `b` as tab-stop placeholders.
+
+---
+
+### User Story 2 - Arithmetic Shift Snippet Insertion (Priority: P1)
+
+An AviUtl script author needs to perform arithmetic bit shifting. They type `SHIFT` and use tab-completion to insert the snippet with placeholders for both arguments.
+
+**Why this priority**: SHIFT is a core bitwise utility function with the same two-argument signature. It completes the set of arithmetic/bitwise global functions.
+
+**Independent Test**: Can be fully tested by typing `SHIFT` in an AviUtl script file and triggering autocomplete. The snippet expands to the function call with tab-stop placeholders.
+
+**Acceptance Scenarios**:
+
+1. **Given** an AviUtl script file is open in the editor, **When** the user types `SHIFT` and triggers snippet expansion, **Then** the editor inserts `SHIFT(a, b)` with `a` and `b` as tab-stop placeholders.
+
+---
+
+### User Story 3 - Debug Print Snippet Insertion (Priority: P1)
+
+An AviUtl script author wants to output debug information. They type `debug_print` and use tab-completion to insert the snippet with a placeholder for the value to print.
+
+**Why this priority**: Debug output is essential for script development workflow. It takes a single string argument and completes the set of requested global function snippets.
+
+**Independent Test**: Can be fully tested by typing `debug_print` in an AviUtl script file and triggering autocomplete. The snippet expands to the function call with a tab-stop placeholder.
+
+**Acceptance Scenarios**:
+
+1. **Given** an AviUtl script file is open in the editor, **When** the user types `debug_print` and triggers snippet expansion, **Then** the editor inserts `debug_print(str)` with `str` as a tab-stop placeholder.
+
+---
+
+### Edge Cases
+
+- What happens when a user types `or` (lowercase) — should it still trigger the `OR` snippet? (No — the trigger must match the exact function name casing, consistent with how the syntax grammar recognizes these as uppercase-only keywords.)
+- What happens when the snippet is triggered outside an AviUtl script context (e.g., plain Lua)? (The snippets are scoped to `source.lua.aviutl-script` only and will not appear in non-AviUtl files.)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The package MUST provide a snippet for each global function: `OR`, `AND`, `XOR`, `SHIFT`, and `debug_print`.
+- **FR-002**: Each snippet MUST use the exact function name (case-sensitive) as its tab trigger.
+- **FR-003**: Each snippet MUST be scoped to `source.lua.aviutl-script` so it only activates in AviUtl script files.
+- **FR-004**: The `OR`, `AND`, `XOR`, and `SHIFT` snippets MUST expand to `FUNC(${1:a},${2:b})$0` format with two tab-stop placeholders.
+- **FR-005**: The `debug_print` snippet MUST expand to `debug_print(${1:str})$0` format with one tab-stop placeholder.
+- **FR-006**: Snippets MUST be provided for both Sublime Text (`.sublime-snippet` files) and VS Code (`aviutl-script.code-snippets` entries).
+- **FR-007**: Each snippet MUST include a Japanese description matching the function's purpose as documented in the AviUtl scripting reference.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All five function snippets (OR, AND, XOR, SHIFT, debug_print) are available and expand correctly when triggered in an AviUtl script file.
+- **SC-002**: Snippet expansion completes in a single trigger action (type name + tab) with no additional steps required.
+- **SC-003**: Tab stops allow the user to fill in all required arguments sequentially without manual cursor repositioning.
+- **SC-004**: Snippets do not appear or interfere when editing non-AviUtl script files.
+
+## Assumptions
+
+- The function signatures are based on the AviUtl scripting reference: OR/AND/XOR/SHIFT each take two numeric arguments; debug_print takes a single string argument.
+- The existing snippet organization pattern is followed: global function snippets are placed alongside `obj.*` method snippets in the `snippet/function/` directory (Sublime) and in the shared `aviutl-script.code-snippets` file (VS Code).
+- Snippet trigger names match the exact function names (uppercase for OR/AND/XOR/SHIFT, lowercase for debug_print) — consistent with how the syntax grammar recognizes them.

--- a/specs/005-global-function-snippets/tasks.md
+++ b/specs/005-global-function-snippets/tasks.md
@@ -28,10 +28,10 @@
 
 ### Implementation for User Story 1
 
-- [ ] T001 [P] [US1] Create OR snippet in `sublime-aviutl-script/snippet/function/OR.sublime-snippet` — scope: `source.lua.aviutl-script`, trigger: `OR`, expansion: `OR(${1:a},${2:b})$0`, description: `OR,AND,XORのビット演算をします。`
-- [ ] T002 [P] [US1] Create AND snippet in `sublime-aviutl-script/snippet/function/AND.sublime-snippet` — scope: `source.lua.aviutl-script`, trigger: `AND`, expansion: `AND(${1:a},${2:b})$0`, description: `OR,AND,XORのビット演算をします。`
-- [ ] T003 [P] [US1] Create XOR snippet in `sublime-aviutl-script/snippet/function/XOR.sublime-snippet` — scope: `source.lua.aviutl-script`, trigger: `XOR`, expansion: `XOR(${1:a},${2:b})$0`, description: `OR,AND,XORのビット演算をします。`
-- [ ] T004 [US1] Add OR, AND, XOR entries to `vscode-aviutl-script/snippets/aviutl-script.code-snippets` — prefix/body/description matching the Sublime snippets above
+- [x] T001 [P] [US1] Create OR snippet in `sublime-aviutl-script/snippet/function/OR.sublime-snippet` — scope: `source.lua.aviutl-script`, trigger: `OR`, expansion: `OR(${1:a},${2:b})$0`, description: `OR,AND,XORのビット演算をします。`
+- [x] T002 [P] [US1] Create AND snippet in `sublime-aviutl-script/snippet/function/AND.sublime-snippet` — scope: `source.lua.aviutl-script`, trigger: `AND`, expansion: `AND(${1:a},${2:b})$0`, description: `OR,AND,XORのビット演算をします。`
+- [x] T003 [P] [US1] Create XOR snippet in `sublime-aviutl-script/snippet/function/XOR.sublime-snippet` — scope: `source.lua.aviutl-script`, trigger: `XOR`, expansion: `XOR(${1:a},${2:b})$0`, description: `OR,AND,XORのビット演算をします。`
+- [x] T004 [US1] Add OR, AND, XOR entries to `vscode-aviutl-script/snippets/aviutl-script.code-snippets` — prefix/body/description matching the Sublime snippets above
 
 **Checkpoint**: OR, AND, XOR snippets functional in both editors
 
@@ -45,8 +45,8 @@
 
 ### Implementation for User Story 2
 
-- [ ] T005 [US2] Create SHIFT snippet in `sublime-aviutl-script/snippet/function/SHIFT.sublime-snippet` — scope: `source.lua.aviutl-script`, trigger: `SHIFT`, expansion: `SHIFT(${1:a},${2:b})$0`, description: `算術シフトをします。`
-- [ ] T006 [US2] Add SHIFT entry to `vscode-aviutl-script/snippets/aviutl-script.code-snippets` — prefix/body/description matching the Sublime snippet above
+- [x] T005 [US2] Create SHIFT snippet in `sublime-aviutl-script/snippet/function/SHIFT.sublime-snippet` — scope: `source.lua.aviutl-script`, trigger: `SHIFT`, expansion: `SHIFT(${1:a},${2:b})$0`, description: `算術シフトをします。`
+- [x] T006 [US2] Add SHIFT entry to `vscode-aviutl-script/snippets/aviutl-script.code-snippets` — prefix/body/description matching the Sublime snippet above
 
 **Checkpoint**: SHIFT snippet functional in both editors
 
@@ -60,8 +60,8 @@
 
 ### Implementation for User Story 3
 
-- [ ] T007 [US3] Create debug_print snippet in `sublime-aviutl-script/snippet/function/debug_print.sublime-snippet` — scope: `source.lua.aviutl-script`, trigger: `debug_print`, expansion: `debug_print(${1:str})$0`, description: `デバック用の表示に使用します。`
-- [ ] T008 [US3] Add debug_print entry to `vscode-aviutl-script/snippets/aviutl-script.code-snippets` — prefix/body/description matching the Sublime snippet above
+- [x] T007 [US3] Create debug_print snippet in `sublime-aviutl-script/snippet/function/debug_print.sublime-snippet` — scope: `source.lua.aviutl-script`, trigger: `debug_print`, expansion: `debug_print(${1:str})$0`, description: `デバック用の表示に使用します。`
+- [x] T008 [US3] Add debug_print entry to `vscode-aviutl-script/snippets/aviutl-script.code-snippets` — prefix/body/description matching the Sublime snippet above
 
 **Checkpoint**: debug_print snippet functional in both editors
 
@@ -71,7 +71,7 @@
 
 **Purpose**: Regression check and final validation
 
-- [ ] T009 Run `vscode-tmgrammar-test` to confirm no grammar regressions in `vscode-aviutl-script/`
+- [x] T009 Run `vscode-tmgrammar-test` to confirm no grammar regressions in `vscode-aviutl-script/`
 
 ---
 

--- a/specs/005-global-function-snippets/tasks.md
+++ b/specs/005-global-function-snippets/tasks.md
@@ -1,0 +1,148 @@
+# Tasks: Global Function Snippets
+
+**Input**: Design documents from `/specs/005-global-function-snippets/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md
+
+**Tests**: TDD is mandatory per project constitution (Principle II). Each snippet is verified via snippet trigger testing in the target editor environment.
+
+**Organization**: Tasks are grouped by user story. All three stories are P1 and independent — they can be implemented in parallel or sequentially.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Sublime snippets**: `sublime-aviutl-script/snippet/function/`
+- **VS Code snippets**: `vscode-aviutl-script/snippets/aviutl-script.code-snippets`
+
+---
+
+## Phase 1: User Story 1 - Bitwise Operation Snippets (Priority: P1)
+
+**Goal**: Provide OR, AND, XOR snippets for both Sublime Text and VS Code
+
+**Independent Test**: Type `OR`, `AND`, or `XOR` in an AviUtl script file and trigger snippet expansion — each should expand to `FUNC(a,b)` with tab-stop placeholders.
+
+### Implementation for User Story 1
+
+- [ ] T001 [P] [US1] Create OR snippet in `sublime-aviutl-script/snippet/function/OR.sublime-snippet` — scope: `source.lua.aviutl-script`, trigger: `OR`, expansion: `OR(${1:a},${2:b})$0`, description: `OR,AND,XORのビット演算をします。`
+- [ ] T002 [P] [US1] Create AND snippet in `sublime-aviutl-script/snippet/function/AND.sublime-snippet` — scope: `source.lua.aviutl-script`, trigger: `AND`, expansion: `AND(${1:a},${2:b})$0`, description: `OR,AND,XORのビット演算をします。`
+- [ ] T003 [P] [US1] Create XOR snippet in `sublime-aviutl-script/snippet/function/XOR.sublime-snippet` — scope: `source.lua.aviutl-script`, trigger: `XOR`, expansion: `XOR(${1:a},${2:b})$0`, description: `OR,AND,XORのビット演算をします。`
+- [ ] T004 [US1] Add OR, AND, XOR entries to `vscode-aviutl-script/snippets/aviutl-script.code-snippets` — prefix/body/description matching the Sublime snippets above
+
+**Checkpoint**: OR, AND, XOR snippets functional in both editors
+
+---
+
+## Phase 2: User Story 2 - Arithmetic Shift Snippet (Priority: P1)
+
+**Goal**: Provide SHIFT snippet for both Sublime Text and VS Code
+
+**Independent Test**: Type `SHIFT` in an AviUtl script file and trigger snippet expansion — should expand to `SHIFT(a,b)` with tab-stop placeholders.
+
+### Implementation for User Story 2
+
+- [ ] T005 [US2] Create SHIFT snippet in `sublime-aviutl-script/snippet/function/SHIFT.sublime-snippet` — scope: `source.lua.aviutl-script`, trigger: `SHIFT`, expansion: `SHIFT(${1:a},${2:b})$0`, description: `算術シフトをします。`
+- [ ] T006 [US2] Add SHIFT entry to `vscode-aviutl-script/snippets/aviutl-script.code-snippets` — prefix/body/description matching the Sublime snippet above
+
+**Checkpoint**: SHIFT snippet functional in both editors
+
+---
+
+## Phase 3: User Story 3 - Debug Print Snippet (Priority: P1)
+
+**Goal**: Provide debug_print snippet for both Sublime Text and VS Code
+
+**Independent Test**: Type `debug_print` in an AviUtl script file and trigger snippet expansion — should expand to `debug_print(str)` with tab-stop placeholder.
+
+### Implementation for User Story 3
+
+- [ ] T007 [US3] Create debug_print snippet in `sublime-aviutl-script/snippet/function/debug_print.sublime-snippet` — scope: `source.lua.aviutl-script`, trigger: `debug_print`, expansion: `debug_print(${1:str})$0`, description: `デバック用の表示に使用します。`
+- [ ] T008 [US3] Add debug_print entry to `vscode-aviutl-script/snippets/aviutl-script.code-snippets` — prefix/body/description matching the Sublime snippet above
+
+**Checkpoint**: debug_print snippet functional in both editors
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+**Purpose**: Regression check and final validation
+
+- [ ] T009 Run `vscode-tmgrammar-test` to confirm no grammar regressions in `vscode-aviutl-script/`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (US1)**: No dependencies — can start immediately
+- **Phase 2 (US2)**: No dependencies — can start immediately (parallel with Phase 1)
+- **Phase 3 (US3)**: No dependencies — can start immediately (parallel with Phase 1, 2)
+- **Phase 4 (Polish)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Independent — OR, AND, XOR snippets
+- **User Story 2 (P1)**: Independent — SHIFT snippet
+- **User Story 3 (P1)**: Independent — debug_print snippet
+- No cross-story dependencies. The only shared file is `aviutl-script.code-snippets` (VS Code), so T004, T006, T008 should run sequentially to avoid merge conflicts.
+
+### Parallel Opportunities
+
+Within User Story 1:
+- T001, T002, T003 can all run in parallel (separate `.sublime-snippet` files)
+- T004 modifies a shared file and should run after T001–T003
+
+Across stories:
+- Sublime snippet tasks (T001–T003, T005, T007) are all independent files and can run in parallel
+- VS Code tasks (T004, T006, T008) all modify the same JSON file — run sequentially
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+# Launch all Sublime snippet tasks for US1 in parallel:
+Task: "Create OR.sublime-snippet"   (T001)
+Task: "Create AND.sublime-snippet"  (T002)
+Task: "Create XOR.sublime-snippet"  (T003)
+
+# Then append to VS Code snippets:
+Task: "Add OR, AND, XOR to aviutl-script.code-snippets" (T004)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (All Stories — Small Feature)
+
+This is a small, well-defined feature. All 3 user stories are P1 and can be delivered together:
+
+1. Complete Phase 1: OR, AND, XOR snippets (Sublime + VS Code)
+2. Complete Phase 2: SHIFT snippet (Sublime + VS Code)
+3. Complete Phase 3: debug_print snippet (Sublime + VS Code)
+4. Complete Phase 4: Regression test
+5. **VALIDATE**: All 5 snippets expand correctly in both editors
+
+### Recommended Execution Order
+
+Since VS Code tasks share a file, the most efficient order is:
+
+1. Create all 5 Sublime `.sublime-snippet` files (T001–T003, T005, T007 — all parallel)
+2. Add all 5 VS Code entries at once (T004 + T006 + T008 — batch into single edit)
+3. Run regression tests (T009)
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Commit after each task per CLAUDE.md convention
+- All snippet content is fully specified in plan.md — no additional research needed
+- Follow existing snippet format exactly (see `sublime-aviutl-script/snippet/function/draw.sublime-snippet` as reference)

--- a/sublime-aviutl-script/snippet/function/AND.sublime-snippet
+++ b/sublime-aviutl-script/snippet/function/AND.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+	<scope>source.lua.aviutl-script</scope>
+	<description>OR,AND,XORのビット演算をします。</description>
+	<content><![CDATA[
+AND(${1:a},${2:b})$0
+]]></content>
+	<tabTrigger>AND</tabTrigger>
+</snippet>

--- a/sublime-aviutl-script/snippet/function/OR.sublime-snippet
+++ b/sublime-aviutl-script/snippet/function/OR.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+	<scope>source.lua.aviutl-script</scope>
+	<description>OR,AND,XORのビット演算をします。</description>
+	<content><![CDATA[
+OR(${1:a},${2:b})$0
+]]></content>
+	<tabTrigger>OR</tabTrigger>
+</snippet>

--- a/sublime-aviutl-script/snippet/function/SHIFT.sublime-snippet
+++ b/sublime-aviutl-script/snippet/function/SHIFT.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+	<scope>source.lua.aviutl-script</scope>
+	<description>算術シフトをします。</description>
+	<content><![CDATA[
+SHIFT(${1:a},${2:b})$0
+]]></content>
+	<tabTrigger>SHIFT</tabTrigger>
+</snippet>

--- a/sublime-aviutl-script/snippet/function/XOR.sublime-snippet
+++ b/sublime-aviutl-script/snippet/function/XOR.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+	<scope>source.lua.aviutl-script</scope>
+	<description>OR,AND,XORのビット演算をします。</description>
+	<content><![CDATA[
+XOR(${1:a},${2:b})$0
+]]></content>
+	<tabTrigger>XOR</tabTrigger>
+</snippet>

--- a/sublime-aviutl-script/snippet/function/debug_print.sublime-snippet
+++ b/sublime-aviutl-script/snippet/function/debug_print.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+	<scope>source.lua.aviutl-script</scope>
+	<description>デバック用の表示に使用します。</description>
+	<content><![CDATA[
+debug_print(${1:str})$0
+]]></content>
+	<tabTrigger>debug_print</tabTrigger>
+</snippet>

--- a/vscode-aviutl-script/snippets/aviutl-script.code-snippets
+++ b/vscode-aviutl-script/snippets/aviutl-script.code-snippets
@@ -273,5 +273,20 @@
     "prefix": "z",
     "body": "obj.z",
     "description": "表示基準座標Z(ReadOnly)"
+  },
+  "OR": {
+    "prefix": "OR",
+    "body": "OR(${1:a},${2:b})$0",
+    "description": "OR,AND,XORのビット演算をします。"
+  },
+  "AND": {
+    "prefix": "AND",
+    "body": "AND(${1:a},${2:b})$0",
+    "description": "OR,AND,XORのビット演算をします。"
+  },
+  "XOR": {
+    "prefix": "XOR",
+    "body": "XOR(${1:a},${2:b})$0",
+    "description": "OR,AND,XORのビット演算をします。"
   }
 }

--- a/vscode-aviutl-script/snippets/aviutl-script.code-snippets
+++ b/vscode-aviutl-script/snippets/aviutl-script.code-snippets
@@ -293,5 +293,10 @@
     "prefix": "SHIFT",
     "body": "SHIFT(${1:a},${2:b})$0",
     "description": "算術シフトをします。"
+  },
+  "debug_print": {
+    "prefix": "debug_print",
+    "body": "debug_print(${1:str})$0",
+    "description": "デバック用の表示に使用します。"
   }
 }

--- a/vscode-aviutl-script/snippets/aviutl-script.code-snippets
+++ b/vscode-aviutl-script/snippets/aviutl-script.code-snippets
@@ -288,5 +288,10 @@
     "prefix": "XOR",
     "body": "XOR(${1:a},${2:b})$0",
     "description": "OR,AND,XORのビット演算をします。"
+  },
+  "SHIFT": {
+    "prefix": "SHIFT",
+    "body": "SHIFT(${1:a},${2:b})$0",
+    "description": "算術シフトをします。"
   }
 }


### PR DESCRIPTION
# Feature Specification: Global Function Snippets

**Feature Branch**: `005-global-function-snippets`
**Created**: 2026-02-15
**Status**: Draft
**Input**: User description: "Add snippets for several functions: OR, AND, XOR (ビット演算), SHIFT (算術シフト), debug_print (デバック用の表示)"

## User Scenarios & Testing *(mandatory)*

### User Story 1 - Bitwise Operation Snippet Insertion (Priority: P1)

An AviUtl script author needs to perform bitwise operations (OR, AND, XOR) on values. They type the function name as a trigger word and use tab-completion to insert the snippet with placeholders for both arguments.

**Why this priority**: Bitwise operations (OR, AND, XOR) share the same two-argument signature `(a, b)` and are the most commonly used global functions among the requested set. Delivering all three together provides immediate value.

**Independent Test**: Can be fully tested by typing `OR`, `AND`, or `XOR` in an AviUtl script file and triggering autocomplete. Each snippet expands to the function call with tab-stop placeholders for arguments.

**Acceptance Scenarios**:

1. **Given** an AviUtl script file is open in the editor, **When** the user types `OR` and triggers snippet expansion, **Then** the editor inserts `OR(a, b)` with `a` and `b` as tab-stop placeholders.
2. **Given** an AviUtl script file is open in the editor, **When** the user types `AND` and triggers snippet expansion, **Then** the editor inserts `AND(a, b)` with `a` and `b` as tab-stop placeholders.
3. **Given** an AviUtl script file is open in the editor, **When** the user types `XOR` and triggers snippet expansion, **Then** the editor inserts `XOR(a, b)` with `a` and `b` as tab-stop placeholders.

---

### User Story 2 - Arithmetic Shift Snippet Insertion (Priority: P1)

An AviUtl script author needs to perform arithmetic bit shifting. They type `SHIFT` and use tab-completion to insert the snippet with placeholders for both arguments.

**Why this priority**: SHIFT is a core bitwise utility function with the same two-argument signature. It completes the set of arithmetic/bitwise global functions.

**Independent Test**: Can be fully tested by typing `SHIFT` in an AviUtl script file and triggering autocomplete. The snippet expands to the function call with tab-stop placeholders.

**Acceptance Scenarios**:

1. **Given** an AviUtl script file is open in the editor, **When** the user types `SHIFT` and triggers snippet expansion, **Then** the editor inserts `SHIFT(a, b)` with `a` and `b` as tab-stop placeholders.

---

### User Story 3 - Debug Print Snippet Insertion (Priority: P1)

An AviUtl script author wants to output debug information. They type `debug_print` and use tab-completion to insert the snippet with a placeholder for the value to print.

**Why this priority**: Debug output is essential for script development workflow. It takes a single string argument and completes the set of requested global function snippets.

**Independent Test**: Can be fully tested by typing `debug_print` in an AviUtl script file and triggering autocomplete. The snippet expands to the function call with a tab-stop placeholder.

**Acceptance Scenarios**:

1. **Given** an AviUtl script file is open in the editor, **When** the user types `debug_print` and triggers snippet expansion, **Then** the editor inserts `debug_print(str)` with `str` as a tab-stop placeholder.

---

### Edge Cases

- What happens when a user types `or` (lowercase) — should it still trigger the `OR` snippet? (No — the trigger must match the exact function name casing, consistent with how the syntax grammar recognizes these as uppercase-only keywords.)
- What happens when the snippet is triggered outside an AviUtl script context (e.g., plain Lua)? (The snippets are scoped to `source.lua.aviutl-script` only and will not appear in non-AviUtl files.)

## Requirements *(mandatory)*

### Functional Requirements

- **FR-001**: The package MUST provide a snippet for each global function: `OR`, `AND`, `XOR`, `SHIFT`, and `debug_print`.
- **FR-002**: Each snippet MUST use the exact function name (case-sensitive) as its tab trigger.
- **FR-003**: Each snippet MUST be scoped to `source.lua.aviutl-script` so it only activates in AviUtl script files.
- **FR-004**: The `OR`, `AND`, `XOR`, and `SHIFT` snippets MUST expand to `FUNC(${1:a},${2:b})$0` format with two tab-stop placeholders.
- **FR-005**: The `debug_print` snippet MUST expand to `debug_print(${1:str})$0` format with one tab-stop placeholder.
- **FR-006**: Snippets MUST be provided for both Sublime Text (`.sublime-snippet` files) and VS Code (`aviutl-script.code-snippets` entries).
- **FR-007**: Each snippet MUST include a Japanese description matching the function's purpose as documented in the AviUtl scripting reference.

## Success Criteria *(mandatory)*

### Measurable Outcomes

- **SC-001**: All five function snippets (OR, AND, XOR, SHIFT, debug_print) are available and expand correctly when triggered in an AviUtl script file.
- **SC-002**: Snippet expansion completes in a single trigger action (type name + tab) with no additional steps required.
- **SC-003**: Tab stops allow the user to fill in all required arguments sequentially without manual cursor repositioning.
- **SC-004**: Snippets do not appear or interfere when editing non-AviUtl script files.

## Assumptions

- The function signatures are based on the AviUtl scripting reference: OR/AND/XOR/SHIFT each take two numeric arguments; debug_print takes a single string argument.
- The existing snippet organization pattern is followed: global function snippets are placed alongside `obj.*` method snippets in the `snippet/function/` directory (Sublime) and in the shared `aviutl-script.code-snippets` file (VS Code).
- Snippet trigger names match the exact function names (uppercase for OR/AND/XOR/SHIFT, lowercase for debug_print) — consistent with how the syntax grammar recognizes them.
